### PR TITLE
Server Sync

### DIFF
--- a/com.weibellab.comms.meta
+++ b/com.weibellab.comms.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3d662a2b429459e429e69800058bc6f3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.weibellab.comms/Editor/reliablecommunicationeditorui.cs
+++ b/com.weibellab.comms/Editor/reliablecommunicationeditorui.cs
@@ -18,6 +18,10 @@ namespace Comms
         private static string[] eventHandlerToolbar = new string[] { "Configuration", "Data Events", "Status Events" };
         private int openTab = 0;
 
+        private static string[] ipStrategyToolbar = new string[] {"Manual", "Web", "UDP"};
+
+        private bool expandWebExtras = false;
+
         private void OnEnable()
         {
             isServer = serializedObject.FindProperty("isServer");
@@ -35,12 +39,40 @@ namespace Comms
                 ToggleButtonStyleToggled.normal.background = ToggleButtonStyleToggled.active.background;
             }
 
-            EditorGUILayout.HelpBox(string.Format("{0}\nTCP {1}{2}", c.Host.Name,
-                    c.isServer ?
-                        string.Format("Server on port {0}", c.ListenPort) :
-                        string.Format("Client of {0}:{1}", c.Host.Address, c.Host.Port, c.Host.Name),
+
+            /* INFO BOX */
+            if (c.isServer) {
+                EditorGUILayout.HelpBox(string.Format("{0}\nTCP {1}{2}", 
+                    c.Host.Name,
+                    string.Format("Server on port {0}", c.ListenPort),
                     (c.dynamicMessageLength ? "" : ("\nStatic Messages with length " + c.fixedMessageLength))
                     ), MessageType.Info, true);
+            }
+            else {
+                if (c.strategy == TargettingStrategy.Web) {
+                    EditorGUILayout.HelpBox(string.Format("{0}\nTCP {1}{2}", 
+                        c.Host.Name,
+                        string.Format("Client of {0} room @ {1}", 
+                            c.room, 
+                            c.webserverSyncAddress),
+                        (c.dynamicMessageLength ? "" : ("\nStatic Messages with length " + c.fixedMessageLength))
+                        ), MessageType.Info, true);
+                }
+                // else if (c.strategy == TargettingStrategy.Udp) {
+
+                // }
+                else {
+                    EditorGUILayout.HelpBox(string.Format("{0}\nTCP {1}{2}", 
+                        c.Host.Name,
+                        string.Format("Client of {0}:{1}", 
+                            c.Host.Address, 
+                            c.Host.Port, 
+                            c.Host.Name),
+                        (c.dynamicMessageLength ? "" : ("\nStatic Messages with length " + c.fixedMessageLength))
+                        ), MessageType.Info, true);
+                }
+            }
+            
             EditorGUILayout.LabelField("", GUILayout.Height(5));
 
             if (c.dropAccumulatedMessages)
@@ -48,11 +80,10 @@ namespace Comms
                 EditorGUILayout.HelpBox("This socket will only call event handlers with the last message received", MessageType.Warning, true);
             }
 
+            /* CONFIG/DATA/STATUS TABS */
             openTab = GUILayout.Toolbar(openTab, eventHandlerToolbar);
             switch (openTab)
             {
-
-
                 case 1: //DataEvents
                     EditorGUILayout.LabelField("Should we drop acummulated packets?", EditorStyles.boldLabel);
                     EditorGUILayout.PropertyField(serializedObject.FindProperty("dropAccumulatedMessages"));
@@ -111,58 +142,137 @@ namespace Comms
                     }
                     GUILayout.EndHorizontal();
                     c.Host.Name = EditorGUILayout.TextField("Endpoint Name", c.Host.Name);
-
-
-                    // Server / Client Address/Port
+                    
                     if (c.isServer)
                     {
                         // Get port to host on
                         c.ListenPort = EditorGUILayout.IntField("Server Port:", c.ListenPort);
                     }
-                    else
-                    {
-                        // Get Server Address
-                        EditorGUILayout.BeginHorizontal();
-                        GUILayout.FlexibleSpace();
-                        EditorGUILayout.LabelField("host:", GUILayout.Width(40));
-                        c.Host.Address = EditorGUILayout.TextField(GUIContent.none, c.Host.Address, GUILayout.MinWidth(40));
-                        EditorGUILayout.LabelField("port:", GUILayout.Width(40));
-                        c.Host.Port = EditorGUILayout.IntField(GUIContent.none, c.Host.Port, GUILayout.MinWidth(40));
-                        EditorGUILayout.EndHorizontal();
-                    }
-                    EditorGUILayout.LabelField("", GUILayout.Height(5));
-                    EditorGUI.indentLevel -= 1;
 
-
-                    // Message Headers
-                    EditorGUILayout.LabelField(string.Format("Message Length ({0})", c.dynamicMessageLength ? "dynamic" : "fixed"), EditorStyles.boldLabel);
-                    EditorGUI.indentLevel += 1;
-                    EditorGUILayout.BeginHorizontal();
-                    if (GUILayout.Button("Toggle for dynamic messages", c.dynamicMessageLength ? ToggleButtonStyleToggled : ToggleButtonStyleNormal))
-                    {
-                        c.dynamicMessageLength = !c.dynamicMessageLength;
+                    /* Connection Strategy (Manual/Web/Udp) */
+                    EditorGUI.indentLevel++;
+                    c.strategy = (TargettingStrategy) GUILayout.Toolbar((int)c.strategy, ipStrategyToolbar);
+                    switch (c.strategy) {
+                        case TargettingStrategy.Manual:
+                            c.strategy = TargettingStrategy.Manual;
+                            this.drawManualIpStrategy(c);
+                            break;
+                        case TargettingStrategy.Web:
+                            c.strategy = TargettingStrategy.Web;
+                            this.drawWebIpStrategy(c);
+                            break;
+                        case TargettingStrategy.UDP:
+                            c.strategy = TargettingStrategy.UDP;
+                            this.drawUdpIpStrategy(c);
+                            break;
+                        default:
+                            EditorGUILayout.LabelField("Unknown type" + c.strategy);
+                            break;
                     }
-                    // if (GUILayout.Button("Time Sent", c.TimeHeader ? ToggleButtonStyleToggled : ToggleButtonStyleNormal))
-                    // {
-                    //     c.TimeHeader = !c.TimeHeader;
-                    // }
-                    // if (GUILayout.Button("Calculate Bandwidth", c.MonitorBandwidth ? ToggleButtonStyleToggled : ToggleButtonStyleNormal))
-                    // {
-                    //     c.MonitorBandwidth = !c.MonitorBandwidth;
-                    //}
-                    EditorGUILayout.EndHorizontal();
-                    if (!c.dynamicMessageLength)
-                    {
-                        c.fixedMessageLength = EditorGUILayout.IntField("Fixed Message Size (bytes)", c.fixedMessageLength);
-                    }
-                    EditorGUI.indentLevel -= 1;
+                    EditorGUI.indentLevel--;
 
+                    this.drawMessageHeaders(c);
                     break;
 
             }
 
             serializedObject.ApplyModifiedProperties();
 
+        }
+
+        public void drawWebIpStrategy(ReliableCommunication c) {
+            EditorGUILayout.LabelField("If your devices are on different networks or have variable IP addresses, you may wish to use this method to find the device before connecting");
+            
+            // Choose a Room
+            EditorGUILayout.BeginHorizontal();
+            EditorGUILayout.LabelField("Room");
+            c.room = EditorGUILayout.TextField(c.room);
+            if (GUILayout.Button("Generate")) {
+                c.room = System.Guid.NewGuid().ToString();
+            }
+            EditorGUILayout.EndHorizontal();
+
+            // Set the passkey
+            EditorGUILayout.BeginHorizontal();
+            EditorGUILayout.LabelField("Passkey");
+            c.key = EditorGUILayout.TextField(c.key);
+            if (GUILayout.Button("Generate")) {
+                c.key = System.Guid.NewGuid().ToString();
+            }
+            EditorGUILayout.EndHorizontal();
+
+            // More
+            this.expandWebExtras = EditorGUILayout.BeginFoldoutHeaderGroup(this.expandWebExtras, "more");
+            if (this.expandWebExtras) {
+                // Set the webserver
+                EditorGUILayout.BeginHorizontal();
+                EditorGUILayout.LabelField("web portal");
+                c.webserverSyncAddress = EditorGUILayout.TextField(c.webserverSyncAddress);
+                EditorGUILayout.EndHorizontal();
+
+                // Set the ID
+                EditorGUILayout.BeginHorizontal();
+                EditorGUILayout.LabelField("ID");
+                c.id = EditorGUILayout.TextField(c.id);
+                if (GUILayout.Button("Generate")) {
+                    c.id = System.Guid.NewGuid().ToString();
+                }
+                EditorGUILayout.EndHorizontal();
+            }
+            EditorGUILayout.EndFoldoutHeaderGroup();
+        }
+
+        public void drawUdpIpStrategy(ReliableCommunication c) {
+            EditorGUILayout.LabelField("Let's setup with Udp");
+        }
+
+        public void drawManualIpStrategy(ReliableCommunication c) {
+            EditorGUILayout.LabelField("Manually set the IP address and port of the device you want to connect to.");
+            // Server / Client Address/Port
+            if (!c.isServer)
+            {
+                // Get Server Address
+                EditorGUILayout.BeginHorizontal();
+                GUILayout.FlexibleSpace();
+                EditorGUILayout.LabelField("host:", GUILayout.Width(40));
+                c.Host.Address = EditorGUILayout.TextField(GUIContent.none, c.Host.Address, GUILayout.MinWidth(40));
+                EditorGUILayout.LabelField("port:", GUILayout.Width(40));
+                c.Host.Port = EditorGUILayout.IntField(GUIContent.none, c.Host.Port, GUILayout.MinWidth(40));
+                EditorGUILayout.EndHorizontal();
+            }
+            EditorGUILayout.LabelField("", GUILayout.Height(5));
+            EditorGUI.indentLevel -= 1;
+        }
+
+
+        /// <summary>
+        /// Draw the GUI for:
+        /// Whether or not to have dynamic message sizes or a fixed message size
+        /// </summary>
+        /// <param name="c"></param>
+        public void drawMessageHeaders(ReliableCommunication c) {
+            // Message Headers
+            EditorGUILayout.LabelField(string.Format("Message Length ({0})", c.dynamicMessageLength ? "dynamic" : "fixed"), EditorStyles.boldLabel);
+            EditorGUI.indentLevel += 1;
+            EditorGUILayout.BeginHorizontal();
+            if (GUILayout.Button("Toggle for dynamic messages", c.dynamicMessageLength ? ToggleButtonStyleToggled : ToggleButtonStyleNormal))
+            {
+                c.dynamicMessageLength = !c.dynamicMessageLength;
+            }
+            // if (GUILayout.Button("Time Sent", c.TimeHeader ? ToggleButtonStyleToggled : ToggleButtonStyleNormal))
+            // {
+            //     c.TimeHeader = !c.TimeHeader;
+            // }
+            // if (GUILayout.Button("Calculate Bandwidth", c.MonitorBandwidth ? ToggleButtonStyleToggled : ToggleButtonStyleNormal))
+            // {
+            //     c.MonitorBandwidth = !c.MonitorBandwidth;
+            //}
+            EditorGUILayout.EndHorizontal();
+            if (!c.dynamicMessageLength)
+            {
+                c.fixedMessageLength = EditorGUILayout.IntField("Fixed Message Size (bytes)", c.fixedMessageLength);
+            }
+            EditorGUI.indentLevel -= 1;
         }
     }
 }

--- a/com.weibellab.comms/Editor/reliablecommunicationeditorui.cs
+++ b/com.weibellab.comms/Editor/reliablecommunicationeditorui.cs
@@ -18,7 +18,7 @@ namespace Comms
         private static string[] eventHandlerToolbar = new string[] { "Configuration", "Data Events", "Status Events" };
         private int openTab = 0;
 
-        private static string[] ipStrategyToolbar = new string[] {"Manual", "Web", "UDP"};
+        private static string[] ipStrategyToolbar = new string[] {"Manual (default)", "Web", "UDP (unsupported)"};
 
         private bool expandWebExtras = false;
 
@@ -125,31 +125,7 @@ namespace Comms
                     break;
 
                 default: // Configuration
-                    EditorGUILayout.LabelField("Socket name, type, and host/port", EditorStyles.boldLabel);
-                    EditorGUI.indentLevel += 1;
-
-                    GUILayout.BeginHorizontal();
-                    EditorGUILayout.LabelField(string.Format("Socket type", GUILayout.Width(10)));
-                    GUILayout.FlexibleSpace();
-                    if (GUILayout.Button("Server", isServer.boolValue ? ToggleButtonStyleToggled : ToggleButtonStyleNormal))
-                    {
-                        isServer.boolValue = true;
-
-                    }
-                    if (GUILayout.Button("Client", !isServer.boolValue ? ToggleButtonStyleToggled : ToggleButtonStyleNormal))
-                    {
-                        isServer.boolValue = false;
-                    }
-                    GUILayout.EndHorizontal();
-                    c.Host.Name = EditorGUILayout.TextField("Endpoint Name", c.Host.Name);
-                    
-                    if (c.isServer)
-                    {
-                        // Get port to host on
-                        c.ListenPort = EditorGUILayout.IntField("Server Port:", c.ListenPort);
-                    }
-
-                    /* Connection Strategy (Manual/Web/Udp) */
+                /* Connection Strategy (Manual/Web/Udp) */
                     EditorGUI.indentLevel++;
                     c.strategy = (TargettingStrategy) GUILayout.Toolbar((int)c.strategy, ipStrategyToolbar);
                     switch (c.strategy) {
@@ -170,6 +146,34 @@ namespace Comms
                             break;
                     }
                     EditorGUI.indentLevel--;
+                    EditorGUILayout.Space();
+
+
+                    EditorGUILayout.LabelField("Socket name, type, and host/port", EditorStyles.boldLabel);
+                    EditorGUI.indentLevel += 1;
+
+                    GUILayout.BeginHorizontal();
+                    EditorGUILayout.LabelField(string.Format("Socket type", GUILayout.Width(10)));
+                    GUILayout.FlexibleSpace();
+                    if (GUILayout.Button("Server", isServer.boolValue ? ToggleButtonStyleToggled : ToggleButtonStyleNormal))
+                    {
+                        isServer.boolValue = true;
+
+                    }
+                    if (GUILayout.Button("Client", !isServer.boolValue ? ToggleButtonStyleToggled : ToggleButtonStyleNormal))
+                    {
+                        isServer.boolValue = false;
+                    }
+                    GUILayout.EndHorizontal();
+                    c.Host.Name = EditorGUILayout.TextField("Connection Name", c.Host.Name);
+                    
+                    if (c.isServer)
+                    {
+                        // Get port to host on
+                        c.ListenPort = EditorGUILayout.IntField("Server Port:", c.ListenPort);
+                    }
+
+                    
 
                     this.drawMessageHeaders(c);
                     break;
@@ -181,12 +185,16 @@ namespace Comms
         }
 
         public void drawWebIpStrategy(ReliableCommunication c) {
-            EditorGUILayout.LabelField("If your devices are on different networks or have variable IP addresses, you may wish to use this method to find the device before connecting");
-            
+            EditorGUILayout.LabelField("If your devices have variable IPs, \nyou may wish to use this method to find\nthe device before connecting.\nUse github.com/WeibelLab/Comms/tree/master/webserver\nfor the server",
+            GUILayout.MinHeight(80),
+            GUILayout.MinWidth(400));
+            EditorGUILayout.Space();
+            // Web Portal
+            c.webserverSyncAddress = EditorGUILayout.TextField("Web Portal", c.webserverSyncAddress);
+
             // Choose a Room
             EditorGUILayout.BeginHorizontal();
-            EditorGUILayout.LabelField("Room");
-            c.room = EditorGUILayout.TextField(c.room);
+            c.room = EditorGUILayout.TextField("Room Name", c.room);
             if (GUILayout.Button("Generate")) {
                 c.room = System.Guid.NewGuid().ToString();
             }
@@ -194,40 +202,33 @@ namespace Comms
 
             // Set the passkey
             EditorGUILayout.BeginHorizontal();
-            EditorGUILayout.LabelField("Passkey");
-            c.key = EditorGUILayout.TextField(c.key);
+            c.key = EditorGUILayout.TextField("Room Passkey", c.key);
             if (GUILayout.Button("Generate")) {
                 c.key = System.Guid.NewGuid().ToString();
             }
             EditorGUILayout.EndHorizontal();
 
-            // More
-            this.expandWebExtras = EditorGUILayout.BeginFoldoutHeaderGroup(this.expandWebExtras, "more");
-            if (this.expandWebExtras) {
-                // Set the webserver
-                EditorGUILayout.BeginHorizontal();
-                EditorGUILayout.LabelField("web portal");
-                c.webserverSyncAddress = EditorGUILayout.TextField(c.webserverSyncAddress);
-                EditorGUILayout.EndHorizontal();
-
-                // Set the ID
-                EditorGUILayout.BeginHorizontal();
-                EditorGUILayout.LabelField("ID");
-                c.id = EditorGUILayout.TextField(c.id);
-                if (GUILayout.Button("Generate")) {
-                    c.id = System.Guid.NewGuid().ToString();
-                }
-                EditorGUILayout.EndHorizontal();
+            // Set the ID
+            EditorGUILayout.BeginHorizontal();
+            c.id = EditorGUILayout.TextField("This Connection's Name", c.id);
+            if (GUILayout.Button("Generate")) {
+                c.id = System.Guid.NewGuid().ToString();
             }
-            EditorGUILayout.EndFoldoutHeaderGroup();
+            EditorGUILayout.EndHorizontal();
         }
 
         public void drawUdpIpStrategy(ReliableCommunication c) {
-            EditorGUILayout.LabelField("Let's setup with Udp");
+            EditorGUILayout.LabelField("This feature haven't been implemented\nit will let you do a local network broadcast\nto find connections", 
+            GUILayout.MinHeight(60),
+            GUILayout.MinWidth(400));
+            EditorGUILayout.Space();
         }
 
         public void drawManualIpStrategy(ReliableCommunication c) {
-            EditorGUILayout.LabelField("Manually set the IP address and port of the device you want to connect to.");
+            EditorGUILayout.LabelField("Manually set the IP address and port\nof the device you want to connect to.",
+            GUILayout.MinHeight(40),
+            GUILayout.MinWidth(400));
+            EditorGUILayout.Space();
             // Server / Client Address/Port
             if (!c.isServer)
             {

--- a/com.weibellab.comms/LICENSE.meta
+++ b/com.weibellab.comms/LICENSE.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 46feb0b6c7663e7418123077229bd554
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.weibellab.comms/Packages.meta
+++ b/com.weibellab.comms/Packages.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 442761e334552df4dafe4de3ade58431
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.weibellab.comms/Packages/manifest.json.meta
+++ b/com.weibellab.comms/Packages/manifest.json.meta
@@ -1,7 +1,6 @@
 fileFormatVersion: 2
-guid: 6910edcc3f22a4613860ebb63b0a9f63
-folderAsset: yes
-DefaultImporter:
+guid: d2c55ec2ac9fe72478ce642bf3cab3db
+TextScriptImporter:
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/com.weibellab.comms/README.md.meta
+++ b/com.weibellab.comms/README.md.meta
@@ -1,7 +1,6 @@
 fileFormatVersion: 2
-guid: ef31837f9330949529c564a497b137db
-folderAsset: yes
-DefaultImporter:
+guid: ee88d1f425349744b9433fbb7f0e5fc1
+TextScriptImporter:
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/com.weibellab.comms/Runtime.meta
+++ b/com.weibellab.comms/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 095e3c36de9c4174286303b5f912d39e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.weibellab.comms/Runtime/CommunicationEndpoint.cs
+++ b/com.weibellab.comms/Runtime/CommunicationEndpoint.cs
@@ -22,6 +22,9 @@ namespace Comms
     public enum CommunicationHeaderType { Length, Time }
 
     [System.Serializable]
+    public enum TargettingStrategy { Manual, Web, UDP }
+
+    [System.Serializable]
     public struct CommunicationEndpoint
     {
         [SerializeField]

--- a/com.weibellab.comms/Third Party Notices.md.meta
+++ b/com.weibellab.comms/Third Party Notices.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a460aa9b0b2311f4f93da6a40628ae0b
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package.json.meta
+++ b/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ae7a01c88533f4a4fb7d340fbefc6641
+PackageManifestImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Adding support to allow ReliableCommunication instances to find each other through a server at a known address. That server only provides the port and IPs of other devices and doesn't route traffic. This only works on a local network.

A sample server can be found at [Comms/webserver](github.com/WeibelLab/Comms/tree/master/webserver).
The server hosts 'rooms' which are created by ReliableCommunication servers.
Each room has a passkey to enter which is set by the ReliableCommunication server. ReliableCommunication clients must know this passkey to enter.

Here is what the update GUI looks like for this method
![image](https://user-images.githubusercontent.com/33668799/116825886-20b93080-ab46-11eb-82ce-e42d3e46fbdf.png)
